### PR TITLE
Improve definition of a frame

### DIFF
--- a/draft-sprang-avtcore-frame-acknowledgement.md
+++ b/draft-sprang-avtcore-frame-acknowledgement.md
@@ -89,7 +89,7 @@ Note that it is allowed to report a frame as decoded even if the decode process 
 
 {::boilerplate bcp14-tagged}
 
-For the purposes of this document, a "frame" is defined as any decodable unit of bitstream data that results in the update to the codec state (e.g. reference buffers, entropy tables, etc) that can be used as a reference for any subsequent decodable unit of bitstream data. Typically that will be a full frame, but also include cases such as a "no show" frame intended for later reference or even a part of a frame such as a tile if it is independently decodable and makes updates encoder state that other tiles/frames can later reference.
+For the purposes of this document, a "frame" is defined as any decodable unit of bitstream data that results in the update to the codec state (e.g. reference buffers, entropy tables, etc) that can be used as a reference for any subsequent decodable unit of bitstream data. Typically that will be a full frame, but also include cases such as a "no show" frame intended for later reference or even a part of a frame such as a tile or a slice if it is independently decodable and makes updates to encoder state that other tiles/frames can later reference.
 
 # Applicability
 


### PR DESCRIPTION
Adds a more unambiguous definition of a frame for the context of this document.

Fixes #2 