### PR TITLE
Add both Frame ID and Frame Feedback Request to the same extensions

### DIFF
--- a/draft-sprang-avtcore-frame-acknowledgement.md
+++ b/draft-sprang-avtcore-frame-acknowledgement.md
@@ -256,12 +256,12 @@ The status vector MUST be padded with 0 to 23 zero bits to align to the next 32-
 
 # Frame ID considerations {#frame_id_considerations}
 
-As stated above, the sender MUST increment the Frame ID by one for each new frame in sending order. More than that, it must make sure that no wrap-around ambiguity can occur.
+As stated above, the sender MUST increment the Frame ID by one for each new frame with the Frame Acknowledgement header extension present, in sending order. More than that, it must make sure that no wrap-around ambiguity can occur.
 Since feedback is only really necessary for frames which the codec stores in a reference buffer pending future use, the number of outstanding frames is in practice limited by the number of available reference buffers. E.g. for AV1, the upper limit will be 8. Although the optimal behavior will be application dependent, it is often advisable to spread reference buffer usage out across an RTT and to cull earlier buffer usage once later frames have been acknowledged.
 
 ## Point-to-Multi-Point
 
-When considering a multi-way application with an SFU/SFM-type relay in the middle, the middlebox may need to do translations/rewriting of Frame IDs such that the outgoing FrameIDs a middlebox to a receiver still fulfills the requirement that the FrameIDs are incremented by one for each new frame that is marked for feedback. This must be true even if independent video streams for different senders are multiplexed onto the same SSRC. Further the middlebox should typically not acknowledge a frame to a sender unless all active receivers have acknowledged that frame.
+When considering a multi-way application with an SFU/SFM-type relay in the middle, the middlebox may need to do translations/rewriting of Frame IDs such that the outgoing FrameIDs from a middlebox to a receiver still fulfill the requirement that the FrameIDs are incremented by one for each new frame that is marked for feedback. This must be true even if independent video streams for different senders are multiplexed onto the same SSRC. Further the middlebox should typically not acknowledge a frame to a sender unless all active receivers have acknowledged that frame.
 
 # Security Considerations
 


### PR DESCRIPTION
This PR removes usage of an external identification mechanism (such as Dependency Descriptors) in favor of having it built-in to the same extensions. 

This makes the logic much cleaner and unambiguous.
Since we now only deal with frames the sender is interested in feedback about, we can reduce the ID to a single 8-bit value. "Being interested in" implies that a reference frame state is being kept in anticipation of being re-used, so up to 256 outstanding frames should be plenty.

