### PR TITLE
Add text describing handling of out-of-order packets

### DIFF
--- a/draft-sprang-avtcore-frame-acknowledgement.md
+++ b/draft-sprang-avtcore-frame-acknowledgement.md
@@ -301,6 +301,10 @@ This mechanism allows for efficient recovery from decoder desynchronization with
 
 When considering a multi-way application with an SFU/SFM-type relay in the middle, the middlebox may need to do translations/rewriting of Frame IDs such that the outgoing FrameIDs from a middlebox to a receiver still fulfill the requirement that the FrameIDs are incremented by one for each new frame that is marked for feedback. This must be true even if independent video streams for different senders are multiplexed onto the same SSRC. Further the middlebox should typically not acknowledge a frame to a sender unless all active receivers have acknowledged that frame.
 
+## Out-of-order Message Handling
+
+Though rare, it is possible that Frame Acknowledgement Request header extensions are received out of order. This can happen due to e.g., network reordering, but more likely due to retransmissions or recovery of packets using FEC. Regardless of the cause, if a Frame ID is present, the receiver must store it and the state associated with the frame in this packet. If a feedback request is contained in the header extension, and no feedback request has been processed with a Frame ID larger than contained in the requested range, the receiver must process the request. Otherwise, the request must be ignored.
+
 # Security Considerations
 
 The messages in this proposal may expose a small amount of data, namely the number of frames that have been sent, and potentially in an indirect way which frames the sender sees as important for recovery.


### PR DESCRIPTION
This addresses how to handle reordering due to for instance retransmissions or FEC recovery.

Fixes #7